### PR TITLE
Make triangle look for specific shader entry point

### DIFF
--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -816,7 +816,7 @@ public:
 		// Load binary SPIR-V shader
 		shaderStages[0].module = loadSPIRVShader(getShadersPath() + "triangle/triangle.vert.spv");
 		// Main entry point for the shader
-		shaderStages[0].pName = "main";
+		shaderStages[0].pName = getShaderEntryPoint(VK_SHADER_STAGE_VERTEX_BIT);
 		assert(shaderStages[0].module != VK_NULL_HANDLE);
 
 		// Fragment shader
@@ -826,7 +826,7 @@ public:
 		// Load binary SPIR-V shader
 		shaderStages[1].module = loadSPIRVShader(getShadersPath() + "triangle/triangle.frag.spv");
 		// Main entry point for the shader
-		shaderStages[1].pName = "main";
+		shaderStages[1].pName = getShaderEntryPoint(VK_SHADER_STAGE_FRAGMENT_BIT);
 		assert(shaderStages[1].module != VK_NULL_HANDLE);
 
 		// Set pipeline shader stage info


### PR DESCRIPTION
This reinstates the behavior after upstream's master sync. Without this triangle did not work.